### PR TITLE
Add recipe for astropy 0.4 and script to automate builds

### DIFF
--- a/astropy-0.4.0/build.sh
+++ b/astropy-0.4.0/build.sh
@@ -1,0 +1,10 @@
+# use the offline option to prevent querying PyPI for a newer
+# version of astropy-helpers. conda build prevents accessing PyPI
+# so omitting --offline raises an exception when astropy_helpers
+# looks for a new version.
+
+#
+# could also be fixed by adding a configuration item to the
+# ah_bootstrap section, I suppose...
+$PYTHON setup.py install --offline
+

--- a/astropy-0.4.0/build.sh
+++ b/astropy-0.4.0/build.sh
@@ -6,5 +6,5 @@
 #
 # could also be fixed by adding a configuration item to the
 # ah_bootstrap section, I suppose...
-$PYTHON setup.py install --offline
+$PYTHON setup.py install --offline --no-git
 

--- a/astropy-0.4.0/meta.yaml
+++ b/astropy-0.4.0/meta.yaml
@@ -1,0 +1,20 @@
+package:
+    name: astropy
+    version: "0.4.0"
+
+source:
+    fn: astropy-0.4.0.tar.gz
+    url: http://pypi.python.org/packages/source/a/astropy/astropy-0.4.tar.gz
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy
+    run:
+        - python
+        - numpy
+

--- a/build_astropy.sh
+++ b/build_astropy.sh
@@ -18,5 +18,4 @@ CONDA_PY=32 CONDA_NPY=18 conda build $astropy_version
 CONDA_PY=32 CONDA_NPY=16 conda build $astropy_version
 CONDA_PY=27 CONDA_NPY=16 conda build $astropy_version
 CONDA_PY=27 CONDA_NPY=15 conda build $astropy_version
-
-
+CONDA_PY=27 CONDA_NPY=17 conda build $astropy_version

--- a/build_astropy.sh
+++ b/build_astropy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Build  astropy recipe specified on command line
+# for the python/numpy version combinations that anaconda
+# does not provide.
+
+if [ $# != 1 ]
+then
+    echo "Usage: build_astropy.sh recipe_name"
+    exit 1
+fi
+
+astropy_version=$1
+
+export PATH=~/miniconda/bin:$PATH
+
+CONDA_PY=32 CONDA_NPY=18 conda build $astropy_version
+CONDA_PY=32 CONDA_NPY=16 conda build $astropy_version
+CONDA_PY=27 CONDA_NPY=16 conda build $astropy_version
+CONDA_PY=27 CONDA_NPY=15 conda build $astropy_version
+
+


### PR DESCRIPTION
There was one issue of note that came up in trying to build the conda packages for astropy 0.4: `conda build` disallows downloading by setuptools, which raises an error when `ah_bootstrap.py` tries to check for a new version of `astropy_helpers`. 

I fixed it for now by adding `--offline` to `setup.py install` in `build.sh`; I suppose a better solution would be building a conda package for `astropy_helpers`, keeping that up to date, and using that package.
